### PR TITLE
Fix SPM deployment target warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,6 @@ import PackageDescription
 let package = Package(
     name: "AgoraRtcKit",
     defaultLocalization: "en",
-    platforms: [.iOS(.v8)],
     products: [
         .library(
             name: "AgoraRtcKit",


### PR DESCRIPTION
Removing the `platforms` parameter avoids this warning in projects that import the Swift package:

`The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 15.0.99.`

A [comparable PR in the SwiftyJSON repo](https://github.com/SwiftyJSON/SwiftyJSON/pull/1067) explains why `platforms` is unnecessary when the minimum iOS deployment target is less than 9 under `swift-tools-version:5.3`.
> Those platforms only specify minimum deployment target, if it is higher than minimum SPM deployment target. Thus if they are omitted, Swift Package will automatically support all platforms supported by current tools.